### PR TITLE
Fix error when `search_facets_limits` not set in the global object

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1288,8 +1288,9 @@ def has_more_facets(facet, search_facets, limit=None, exclude_active=False):
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
-    if c.search_facets_limits and limit is None:
-        limit = c.search_facets_limits.get(facet)
+    if hasattr(c, 'search_facets_limits'):
+        if c.search_facets_limits and limit is None:
+            limit = c.search_facets_limits.get(facet)
     if limit is not None and len(facets) > limit:
         return True
     return False


### PR DESCRIPTION
It seems that `search_facets_limits` is not always set in the global object, as such `has_more_facets` crashes when it tries to access it. This change implements the same check as in the `get_facet_items_dict` function in order to deal with this issue.